### PR TITLE
Fix undefined name object crash

### DIFF
--- a/lib/profile.js
+++ b/lib/profile.js
@@ -14,9 +14,9 @@ exports.parse = function(json) {
   var profile = {};
 
   profile.id = String(_json.id);
-  profile.name = _json.name;
-  profile.displayName = _json.name.givenName + ' ' + _json.name.familyName;
-  profile.userName = _json.userName
+  profile.name = _parseName(_json);
+  profile.displayName = _parseDisplayName(_json);
+  profile.userName = _json.userName;
   profile.emails = _parseEmails(_json);
   profile.groups = _json.groups;
 
@@ -26,6 +26,18 @@ exports.parse = function(json) {
 //
 // Private
 //
+function _parseName(json) {
+  return json.name || {givenName: '', familyName: ''}
+}
+
+function _parseDisplayName(json) {
+  var nameObj = json.name || {}
+  var nameItems = []
+  if (nameObj.givenName) {nameItems.push(nameObj.givenName)}
+  if (nameObj.familyName) {nameItems.push(nameObj.familyName)}
+
+  return nameItems.join(' ')
+}
 
 function _parseEmails(json) {
   var emails = [];


### PR DESCRIPTION
Fixes nutanix/gatekeeper#15

This PR fixes a corner case that can cause profile parsing to crash the app should the `name` object come back as undefined.
