### PR TITLE
Fix state being persisted in wso2 by returning a copy of authorizationParams

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -88,7 +88,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
  * @api protected
  */
 Strategy.prototype.authorizationParams = function(options) {
-  return this._authorizationParams
+  return JSON.parse(JSON.stringify(this._authorizationParams));
 }
 
 /**
@@ -99,7 +99,7 @@ Strategy.prototype.authorizationParams = function(options) {
  * @api protected
  */
 Strategy.prototype.tokenParams = function(options) {
-  return this._tokenParams;
+  return JSON.parse(JSON.stringify(this._tokenParams));
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-wso2",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "WSO2 Identity Server authentication strategy for Passport.",
   "main": "./lib",
   "author": {


### PR DESCRIPTION
This commit addresses the redirect issue on portal access through gatekeeper. The user was getting redirected to urls based on state parameter set in wso2 strategy object. The state parameter was getting set by previous requests to portal and login redirects associated with it. The fix is to return a copy of startegy object's properties instead of returning reference, so that requests do not update the strategy object directly.
